### PR TITLE
Cross-build with Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val supportedScalaVersions = List(scala213, scala3)
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 val zioNioVersion     = "2.0.0"
-val zioProcessVersion = "0.7.0"
+val zioProcessVersion = "0.7.1"
 val zioVersion        = "2.0.0"
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
 lazy val scala213 = "2.13.8"
-lazy val scala3   = "3.1.0"
+lazy val scala3   = "3.1.2"
 
 inThisBuild(
   List(
     name               := "zio-tui",
     normalizedName     := "zio-tui",
     organization       := "io.github.kitlangton",
-    scalaVersion       := scala213,
-    crossScalaVersions := Seq(scala213),
+    scalaVersion       := scala3,
+    crossScalaVersions := Seq(scala213, scala3),
     homepage           := Some(url("https://github.com/kitlangton/zio-tui")),
     licenses           := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
@@ -21,7 +21,7 @@ inThisBuild(
   )
 )
 
-lazy val supportedScalaVersions = List(scala213)
+lazy val supportedScalaVersions = List(scala213, scala3)
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
@@ -29,10 +29,9 @@ val zioNioVersion     = "2.0.0"
 val zioProcessVersion = "0.7.0"
 val zioVersion        = "2.0.0"
 
+
 val sharedSettings = Seq(
-  addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.13.2" cross CrossVersion.full),
-  addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),
-  scalacOptions ++= Seq("-Xfatal-warnings"),
+  // addCompilerPlugin(),
   resolvers ++= Seq(
     "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     "Sonatype OSS Snapshots s01" at "https://s01.oss.sonatype.org/content/repositories/snapshots"
@@ -43,8 +42,24 @@ val sharedSettings = Seq(
     "dev.zio" %%% "zio-test"     % zioVersion % Test,
     "dev.zio" %%% "zio-test-sbt" % zioVersion % Test
   ),
-  scalacOptions ++= Seq("-Ymacro-annotations", "-Xfatal-warnings", "-deprecation"),
-  scalaVersion := scala213,
+  libraryDependencies ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((3, _)) => Seq()
+      case Some((2, 12 | 13)) => Seq(
+        compilerPlugin("org.typelevel" %% "kind-projector"     % "0.13.2" cross CrossVersion.full),
+        compilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1")
+      )
+    }
+  },
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((3, _)) => Seq("-Ykind-projector:underscores", "-source:future")
+      case Some((2, 12 | 13)) => Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders", "-Ymacro-annotations")
+    }
+  },
+  scalacOptions ++= Seq("-Xfatal-warnings", "-deprecation"),
+  scalaVersion := scala3,
+  crossScalaVersions := Seq(scala213, scala3),
   testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
 )
 
@@ -93,7 +108,7 @@ lazy val core = (project in file("./modules/core"))
     ),
     libraryDependencies ++= Seq(
       "dev.zio"  %% "zio-process" % zioProcessVersion,
-      "dev.zio"  %% "zio-nio"     % zioNioVersion,
+      "dev.zio"  %% "zio-nio"     % zioNioVersion exclude("org.scala-lang.modules","scala-collection-compat_2.13"),
       "org.jline" % "jline"       % "3.21.0"
     ),
     resolvers ++= Seq(

--- a/modules/core/src/main/scala/tui/Main.scala
+++ b/modules/core/src/main/scala/tui/Main.scala
@@ -18,7 +18,7 @@ object Main extends App {
     View.vertical(
       deps.map { dep =>
         View.text(dep.padTo(20, ' ')).cyan
-      }: _*
+      }*
     )
 
   val view =
@@ -29,7 +29,8 @@ object Main extends App {
     )
 
   val run =
-    Unsafe.unsafe { implicit unsafe =>
+    Unsafe.unsafe { (unsafe0: Unsafe) =>
+      implicit val unsafe: Unsafe = unsafe0
       zio.Runtime.default.unsafe.run {
         {
           for {

--- a/modules/core/src/main/scala/tui/Main.scala
+++ b/modules/core/src/main/scala/tui/Main.scala
@@ -29,8 +29,7 @@ object Main extends App {
     )
 
   val run =
-    Unsafe.unsafe { (unsafe0: Unsafe) =>
-      implicit val unsafe: Unsafe = unsafe0
+    Unsafe.unsafe { implicit (unsafe: Unsafe) =>
       zio.Runtime.default.unsafe.run {
         {
           for {

--- a/modules/core/src/main/scala/tui/TerminalApp.scala
+++ b/modules/core/src/main/scala/tui/TerminalApp.scala
@@ -2,10 +2,10 @@ package tui
 
 import tui.TerminalApp.Step
 import view.View.string2View
-import view._
+import view.*
 import tui.components.{Choose, LineInput}
-import zio.stream._
-import zio._
+import zio.stream.*
+import zio.*
 
 trait TerminalApp[-I, S, +A] { self =>
   def run(initialState: S): RIO[TUI, A] =

--- a/modules/core/src/main/scala/tui/components/Choose.scala
+++ b/modules/core/src/main/scala/tui/components/Choose.scala
@@ -1,6 +1,6 @@
 package tui.components
 
-import zio._
+import zio.*
 import view.View.string2View
 import view.{KeyEvent, View}
 import tui.TerminalApp.Step
@@ -17,7 +17,7 @@ case class Choose[A](renderA: A => View) extends TerminalApp[Nothing, Choose.Sta
 
     View
       .vertical(
-        "CHOOSE".green :: renderedViews: _*
+        ("CHOOSE".green :: renderedViews)*
       )
 
   }

--- a/modules/core/src/main/scala/view/Input.scala
+++ b/modules/core/src/main/scala/view/Input.scala
@@ -4,7 +4,7 @@ import org.jline.keymap.{BindingReader, KeyMap}
 import org.jline.terminal.Terminal.{Signal, SignalHandler}
 import org.jline.terminal.{Attributes, Terminal, TerminalBuilder}
 import org.jline.utils.InfoCmp.Capability
-import zio._
+import zio.*
 import zio.stream.ZStream
 
 object Input {
@@ -91,11 +91,12 @@ object Input {
 
   // TODO: De-register handle when done
   val keyEventStream: ZStream[Any, Throwable, KeyEvent] =
-    ZStream.repeatZIO(readBinding) merge
+    ZStream.repeatZIO(readBinding).merge(
       ZStream.async[Any, Nothing, KeyEvent](register =>
         terminal.handle(
           Signal.INT,
           _ => register(ZIO.succeed(Chunk(KeyEvent.Exit)))
         )
       )
+    )
 }

--- a/modules/core/src/main/scala/view/Size.scala
+++ b/modules/core/src/main/scala/view/Size.scala
@@ -1,6 +1,6 @@
 package view
 
-case class Size private (width: Int, height: Int) { self =>
+case class Size (width: Int, height: Int) { self =>
   def scaled(dx: Int, dy: Int): Size =
     Size(width + dx, height + dy)
 

--- a/modules/core/src/test/scala/view/TextMapSpec.scala
+++ b/modules/core/src/test/scala/view/TextMapSpec.scala
@@ -1,8 +1,8 @@
 package view
 
 import tui.components.Choose
-import zio.test._
-import zio._
+import zio.test.*
+import zio.*
 
 object TextMapSpec extends ZIOSpecDefault {
 


### PR DESCRIPTION
These changes allow cross-building against Scala 2.13 and 3.
Without better-monadic-for, a lot of syntactic rewrites (mostly involving *) wouldn't have been needed, but it would have cost an ugly tuple unpacking.